### PR TITLE
Fix Warning: To load an ES module, set "type": "module"

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,4 +1,3 @@
-import type { Config } from "tailwindcss";
 import defaultTheme from "tailwindcss/defaultTheme";
 
 export default {
@@ -88,4 +87,4 @@ export default {
     },
   },
   plugins: [require("tailwindcss-animate")],
-} satisfies Config;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "**/.server/**/*.tsx",
     "**/.client/**/*.ts",
     "**/.client/**/*.tsx"
-  ],
+, "tailwind.config.mjs"  ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/node", "vite/client"],


### PR DESCRIPTION
closes #29 

## Description

Fix Warning: To load an ES module, set "type": "module" when run using node v22

## Screenshot / Screen Recording

### Before This PR

<img width="707" alt="image" src="https://github.com/user-attachments/assets/469a1136-e792-43c5-ae22-8c24bdbd7713">


### After This PR

<img width="463" alt="image" src="https://github.com/user-attachments/assets/0b0ed5a6-b4f0-4c71-9e7f-1173f57c4854">
<img width="409" alt="image" src="https://github.com/user-attachments/assets/4f607978-85e1-4bc8-bcc0-e6d3c3efd905">

## References
- https://github.com/tailwindlabs/tailwindcss/discussions/13713
- https://github.com/remix-run/remix/discussions/9461
